### PR TITLE
ACP-2626 Return error response in case of no handler was executed.

### DIFF
--- a/src/Spryker/Zed/AppWebhook/Business/WebhookHandler/WebhookHandler.php
+++ b/src/Spryker/Zed/AppWebhook/Business/WebhookHandler/WebhookHandler.php
@@ -29,6 +29,12 @@ class WebhookHandler
             $webhookResponseTransfer = $webhookHandlerPlugin->handleWebhook($webhookRequestTransfer, $webhookResponseTransfer);
         }
 
+        if ($webhookResponseTransfer->getIsSuccessful() === null) {
+            $webhookResponseTransfer
+                ->setIsSuccessful(false)
+                ->setMessage(sprintf('The webhook was not handled by any of the registered plugins. WebhookRequestTransfer: %s', json_encode($webhookRequestTransfer->toArray())));
+        }
+
         return $webhookResponseTransfer;
     }
 }

--- a/tests/SprykerTest/Glue/AppWebhookBackendApi/RestApi/AppWebhookApiTest.php
+++ b/tests/SprykerTest/Glue/AppWebhookBackendApi/RestApi/AppWebhookApiTest.php
@@ -54,6 +54,24 @@ class AppWebhookApiTest extends Unit
         $this->assertSame('POST content is required.', $glueResponseTransfer->getErrors()[0]->getMessage());
     }
 
+    public function testGivenAValidGlueRequestWhenTheRequestIsNotHandledByAnyOfTheAttachedPluginsThenAnExceptionIsThrownHttpStatus400IsReturnedTogetherWithAMessageInTheGlueResponseTransfer(): void
+    {
+        // Arrange
+        $glueRequestTransfer = new GlueRequestTransfer();
+        $glueRequestTransfer
+            ->setContent('{"key": "value"}')
+            ->setPath('/webhooks');
+
+        $webhooksController = new WebhooksController();
+
+        // Act
+        $glueResponseTransfer = $webhooksController->postAction($glueRequestTransfer);
+
+        // Assert
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $glueResponseTransfer->getHttpStatus());
+        $this->assertCount(1, $glueResponseTransfer->getErrors());
+    }
+
     public function testGivenAValidGlueRequestWhenTheRequestIsHandledAndTheWebhookResponseIsSuccessfulThenAHttpStatus200IsReturnedInTheGlueResponseTransfer(): void
     {
         // Arrange


### PR DESCRIPTION
## PR Description

- Ensure that a Webhook must be handled by at least one handler.

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
